### PR TITLE
Integrate linter with dev server, and lint config & script files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,9 @@ module.exports = {
     'arrow-parens': ['error', 'as-needed', {
       requireForBlockBody: true
     }],
-    'arrow-body-style': ['off']
+    'arrow-body-style': ['off'],
+    // Allow importing devDependencies at the top level: rule is re-enabled
+    // within the frontend and backend directories
+    'import/no-extraneous-dependencies': ['off'],
   }
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 
-script: "npm run ci"
+script: "npm test"
+
+env:
+- CI=1
 
 node_js:
   - "7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,5 @@ node_js:
   - "7"
   - "6"
   - "5"
-  - "4"
 
 sudo: false

--- a/README.md
+++ b/README.md
@@ -21,20 +21,18 @@ Navigate to the following prototypes in your browser:
 
 ### React front-end
 
-`cd` into the `image-annotator` directory and run `npm install` to install front-end dependencies; then run `npm start` to launch the webpack dev server. The application will then be available at [localhost:8080](http://localhost:8080).
-
-The application currently expects [AJL-U/openfaces](https://github.com/AJL-U/openfaces) to be running in parallel, on port 8181: images are loaded from this repository.
+Run `npm install` to install front-end dependencies; then run `npm start` to launch the webpack dev server. The application will then be available at [localhost:8080](http://localhost:8080).
 
 #### Other commands
 
 These commands are available after installation within the `image-annotator/` directory:
 
-- `npm test`: run unit tests with Jest
+- `npm test`: run unit tests with Jest, then lint on exit
 - `npm run lint`: run ESLint to identify syntax & style issues in the code
 - `npm run build`: generate a static build into `image-annotator/dist`
 
+### Instructions for Ubuntu 16 dev environment setup:
 
-### Instrcutions for Ubuntu 16 dev environment setup:
 $ sudo su postgres;
 $ CREATE DATABASE image-annotator;
 

--- a/config.js
+++ b/config.js
@@ -1,6 +1,8 @@
+/* eslint-disable object-shorthand */
 require('dotenv').config({
-  silent: true
+  silent: true,
 });
+
 const ENV = process.env.NODE_ENV || 'development';
 
 const DEV = ENV === 'development';
@@ -28,7 +30,7 @@ module.exports = {
     user: process.env.PGUSER,
     password: process.env.PGPASS,
     url: process.env.DATABASE_URL,
-    ssl: process.env.PGSSLMODE || PROD
-  }
+    ssl: process.env.PGSSLMODE || PROD,
+  },
 };
 

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  rules: {
+    'import/no-extraneous-dependencies': ['error', {
+      devDependencies: ['**/__tests__/*.js']
+    }]
+  }
+};

--- a/jest/run.js
+++ b/jest/run.js
@@ -2,10 +2,11 @@ process.env.NODE_ENV = 'test';
 process.env.PUBLIC_URL = '';
 
 const jest = require('jest');
+
 const argv = process.argv.slice(2);
 
 // Watch unless on CI
-if (!process.env.CI) {
+if (! process.env.CI) {
   argv.push('--watch');
 }
 

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "start": "webpack-dev-server",
     "server:prod": "node backend/server",
     "server:dev": "supervisor -w backend/ backend/server",
-    "lint": "eslint --ext js,jsx frontend",
-    "test": "node jest/run.js",
-    "ci": "npm test && npm run lint"
+    "lint": "eslint --ext js,jsx ./*.js frontend jest",
+    "test:dev": "node jest/run.js",
+    "test": "node jest/run.js && npm run lint"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -77,6 +77,7 @@
     "css-loader": "^0.26.1",
     "eslint": "^3.14.1",
     "eslint-config-airbnb": "^14.0.0",
+    "eslint-loader": "^1.6.3",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^3.0.2",
     "eslint-plugin-react": "^6.9.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "babel-core": "^6.22.1",
     "babel-jest": "^19.0.0",
     "babel-loader": "^6.2.10",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
     "babel-plugin-transform-object-rest-spread": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.22.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,6 @@
+/* eslint-disable global-require */
 module.exports = {
   plugins: [
-    require('autoprefixer')()
-  ]
+    require('autoprefixer')(),
+  ],
 };

--- a/sample-data/sample-data.js
+++ b/sample-data/sample-data.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /* template:
 {
   name: "",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,9 +5,10 @@ const objectHash = require('node-object-hash');
 
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
+
 const hardSourceCacheDir = findCacheDir({
   // Render into node_modules/.cache/hard-source/[confighash]/...
-  name: 'hard-source/[confighash]'
+  name: 'hard-source/[confighash]',
 });
 
 module.exports = {
@@ -35,7 +36,7 @@ module.exports = {
     path: resolve(__dirname, 'dist'),
 
     // necessary for HMR to know where to load the hot update chunks
-    publicPath: '/'
+    publicPath: '/',
   },
 
   devServer: {
@@ -67,12 +68,21 @@ module.exports = {
               // directory for faster rebuilds. We use findCacheDir() because of:
               // https://github.com/facebookincubator/create-react-app/issues/483
               cacheDirectory: findCacheDir({
-                name: 'react-scripts'
-              })
-            }
-          }
+                name: 'react-scripts',
+              }),
+            },
+          },
+          // Before running code through babel, check it for lint errors
+          {
+            loader: 'eslint-loader',
+            options: {
+              // emit all errors as warnings: this lets us see all issues in the
+              // dev console, but the presence of errors will not block rebuilds
+              emitWarning: true,
+            },
+          },
         ],
-        exclude: /node_modules/
+        exclude: /node_modules/,
       },
       {
         test: /\.styl$/,
@@ -82,17 +92,17 @@ module.exports = {
             loader: 'css-loader',
             options: {
               modules: true,
-              localIdentName: '[path][name]--[local]--[hash:base64:5]'
-            }
+              localIdentName: '[path][name]--[local]--[hash:base64:5]',
+            },
           },
           'postcss-loader', // See postcss.config.js for options
-          'stylus-loader'
+          'stylus-loader',
         ],
       },
       {
         test: /\.(png|svg|jpg|gif)$/,
-        loader: 'url-loader?limit=10000'
-      }
+        loader: 'url-loader?limit=10000',
+      },
     ],
   },
 
@@ -109,7 +119,7 @@ module.exports = {
 
     // Inject generated scripts into the frontend/index.html template
     new HtmlWebpackPlugin({
-      template: './index.html'
+      template: './index.html',
     }),
 
     // Use hard source caching for faster rebuilds
@@ -120,7 +130,7 @@ module.exports = {
       // Build a string value used by HardSource to determine which cache to
       // use if [confighash] is in cacheDirectory, or if the cache should be
       // replaced if [confighash] does not appear in cacheDirectory.
-      configHash: (webpackConfig) => objectHash().hash(webpackConfig)
+      configHash: webpackConfig => objectHash().hash(webpackConfig),
     }),
   ],
 


### PR DESCRIPTION
This PR exposes lint errors in the developer console using the `eslint-loader` webpack loader:

![image](https://cloud.githubusercontent.com/assets/442115/23630486/4e580e68-0289-11e7-8396-cb94ed193a8e.png)

Exposing the errors in this way makes it easier to ID and resolve issues as they occur, rather than relying on a tedious linting process prior to commit.

See MoOx/eslint-loader#78 for one issue with this approach: changes that do not affect the AST (purely stylistic things like adding a missing trailing comma) will not trigger a bundle re-build. To be sure you're seeing all available lint output, run the `npm run lint` command from the console.

**Note**: For simplicity, this PR drops CI support for Node 4, so that we can remove the es2015 modules plugin; this behavior works as expected on Node 5 and above. If this is undesirable we can reinstate the plugin but it seemed like supporting Node 6 officially would be sufficient.