### PR TITLE
Re-point annotations API to live API demographic annotation types endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,6 @@ node_modules
 # Build caches
 .cache
 
+logfile
 
 .env

--- a/README.md
+++ b/README.md
@@ -33,12 +33,16 @@ These commands are available after installation within the `image-annotator/` di
 
 ### Instructions for Ubuntu 16 dev environment setup:
 
-$ $ sudo apt-get install postgresql
+$ sudo apt-get install postgresql
+
 $ sudo su postgres
+
 $ CREATE DATABASE image-annotator;
 
 $ sudo service postgresql stop
+
 $ sudo vim /etc/postgresql/9.5/main/pg_hba.conf
+
 ```
   # "local" is for Unix domain socket connections only
   local   all             all                                     trust
@@ -55,3 +59,18 @@ PGUSER=postgres
 ```
 
 npm run migrate:up
+
+
+### Instructions for Mac OS dev environment setup:
+
+_The postgres installation step assumes you are using the [Homebrew](https://brew.sh/) package manager_
+
+$ brew install postgresql
+
+$ brew services start postgresql
+
+$ createdb image-annotator
+
+_(on subsequent runs PostgreSQL should now auto-start)_
+
+$ npm run migrate:up

--- a/frontend/services/face-api.js
+++ b/frontend/services/face-api.js
@@ -65,8 +65,9 @@ export function getAllFaces() {
 }
 
 export function getAnnotations() {
-  return axios.get('/annotations.json')
+  return axios.get('/api/annotations/types')
     // Axios exposes JSON response body as .data property
-    // Returned object is an object with an annotations key
-    .then(result => result.data.annotations);
+    .then(result => ({
+      demographics: result.data,
+    }));
 }


### PR DESCRIPTION
Adjusting the shape of the reducer to not expect a nested demographics key will come later in a second pass, so as not to cause a gnarly merge situation.

This also adds basic setup README instructions for OSX