### PR TITLE
Convert "if" statements in Reducers to use switch () {}

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
   },
   rules: {
     'comma-dangle': ['error', 'always-multiline'],
+    'indent': ['error', 2, { SwitchCase: 0 }],
     'no-console': ['off'],
     'padded-blocks': ['off'],
     'quote-props': ['error', 'as-needed'],

--- a/frontend/redux/reducers/annotations.js
+++ b/frontend/redux/reducers/annotations.js
@@ -15,23 +15,29 @@ import {
 // Each of these methods reduces the state property that shares its name
 
 function workloadId(state = null, action) {
-  if (action.type === RECEIVE_WORKLOAD) {
+  switch (action.type) {
+  case RECEIVE_WORKLOAD:
     return action.payload[0].id;
+
+  default:
+    return state;
   }
-  return state;
 }
 
 function images(state = [], action) {
-  if (action.type === RECEIVE_WORKLOAD) {
+  switch (action.type) {
+  case RECEIVE_WORKLOAD:
     return [];
-  }
-  if (action.type === SAVE_DEMOGRAPHIC_ANNOTATIONS) {
+
+  case SAVE_DEMOGRAPHIC_ANNOTATIONS:
     return state.concat({
       id: action.payload.id,
       annotations: action.payload.demographics,
     });
+
+  default:
+    return state;
   }
-  return state;
 }
 
 export default combineReducers({

--- a/frontend/redux/reducers/demographics.js
+++ b/frontend/redux/reducers/demographics.js
@@ -9,30 +9,37 @@ import {
  } from '../actions';
 
 function order(state = [], action) {
-  if (action.type === RECEIVE_ANNOTATIONS) {
+  switch (action.type) {
+  case RECEIVE_ANNOTATIONS:
     return action.payload.map(question => question.name);
+
+  default:
+    return state;
   }
-  return state;
 }
 
 function questions(state = {}, action) {
-  if (action.type === RECEIVE_ANNOTATIONS) {
+  switch (action.type) {
+  case RECEIVE_ANNOTATIONS:
     return action.payload.reduce((newState, item) => ({
       ...newState,
       [item.name]: item,
     }), {});
+
+  default:
+    return state;
   }
-  return state;
 }
 
 function current(state = 0, action) {
-  if ([
-    RECEIVE_ANNOTATIONS,
-    SAVE_DEMOGRAPHIC_ANNOTATIONS,
-  ].includes(action.type)) {
+  switch (action.type) {
+  case RECEIVE_ANNOTATIONS:
+  case SAVE_DEMOGRAPHIC_ANNOTATIONS:
     return 0;
+
+  default:
+    return state;
   }
-  return state;
 }
 
 export default combineReducers({

--- a/frontend/redux/reducers/loading.js
+++ b/frontend/redux/reducers/loading.js
@@ -14,44 +14,37 @@ const defaultState = {
 };
 
 export default function loadingReducer(state = defaultState, action) {
+  switch (action.type) {
 
-  if (action.type === REQUEST_ANNOTATIONS) {
+  case REQUEST_ANNOTATIONS:
     return {
       ...state,
       annotations: true,
     };
-  }
 
-  if ([
-    RECEIVE_ANNOTATIONS,
-    REQUEST_ANNOTATIONS_FAILED,
-  ].includes(action.type)) {
+  case RECEIVE_ANNOTATIONS:
+  case REQUEST_ANNOTATIONS_FAILED:
     return {
       ...state,
       annotations: false,
     };
-  }
 
-  if ([
-    REQUEST_WORKLOAD,
-    COMPLETE_WORKLOAD,
-  ].includes(action.type)) {
+  case REQUEST_WORKLOAD:
+  case COMPLETE_WORKLOAD:
     return {
       ...state,
       workload: true,
     };
-  }
 
-  if ([
-    RECEIVE_WORKLOAD,
-    REQUEST_WORKLOAD_FAILED,
-    COMPLETE_WORKLOAD_FAILED,
-  ].includes(action.type)) {
+  case RECEIVE_WORKLOAD:
+  case REQUEST_WORKLOAD_FAILED:
+  case COMPLETE_WORKLOAD_FAILED:
     return {
       ...state,
       workload: false,
     };
-  }
 
-  return state;
+  default:
+    return state;
+  }
 }

--- a/frontend/redux/reducers/workload.js
+++ b/frontend/redux/reducers/workload.js
@@ -11,43 +11,55 @@ import {
 } from '../actions';
 
 function id(state = null, action) {
-  if (action.type === RECEIVE_WORKLOAD) {
+  switch (action.type) {
+  case RECEIVE_WORKLOAD:
     return action.payload[0].id;
+
+  default:
+    return state;
   }
-  return state;
 }
 
 function todo(state = [], action) {
-  if (action.type === REQUEST_WORKLOAD) {
+  switch (action.type) {
+  case REQUEST_WORKLOAD:
     return [];
-  }
-  if (action.type === SAVE_DEMOGRAPHIC_ANNOTATIONS) {
+
+  case SAVE_DEMOGRAPHIC_ANNOTATIONS:
     return state.slice(1);
-  }
-  if (action.type === RECEIVE_WORKLOAD) {
+
+  case RECEIVE_WORKLOAD:
     return action.payload[0].images.map(item => item.id);
+
+  default:
+    return state;
   }
-  return state;
 }
 
 function byId(state = {}, action) {
-  if (action.type === RECEIVE_WORKLOAD) {
+  switch (action.type) {
+  case RECEIVE_WORKLOAD:
     return action.payload[0].images.reduce((newState, item) => ({
       ...newState,
       [item.id]: item,
     }), {});
+
+  default:
+    return state;
   }
-  return state;
 }
 
 function complete(state = [], action) {
-  if (action.type === SAVE_DEMOGRAPHIC_ANNOTATIONS) {
+  switch (action.type) {
+  case SAVE_DEMOGRAPHIC_ANNOTATIONS:
     return state.concat(action.payload.id);
-  }
-  if (action.type === RECEIVE_WORKLOAD) {
+
+  case RECEIVE_WORKLOAD:
     return [];
+
+  default:
+    return state;
   }
-  return state;
 }
 
 export default combineReducers({


### PR DESCRIPTION
`switch ()` statements are [the convention used in the Redux docs][docs], and @gnarf had advocated for porting over our existing reducer code to reduce the delta between conventions and our own practices within this repository.

The specific improvement is that
```js

function simpleReducer(state, action) {
  switch (action.type) {
  case '1':
    return 'Handle 1';
  default:
    return state;
  }
}

function complexReducer(state, action) {
  switch (action.type) {
  case '1':
  case '2':
    return 'Handle 1 & 2';
  default:
    return state;
  }
}
```

is more consistent & readable than using `if` in some place, and `if ( [].includes() )` in others, as I had been doing:

```js
function simpleReducer(state, action) {
  if (action.type === '1') {
    return 'Handle 1';
  }
  return state;
}

function complexReducer(state, action) {
  if ([
    '1',
    '2',
  ].includes(action.type)) {
    return 'Handle 1 & 2';
  }
  return 'Handle 2';
}

```

[docs]: http://redux.js.org/docs/basics/Reducers.html#note-on-switch-and-boilerplate