### PR TITLE
Re-structure annotation form for better ux flow with fewer errors

### DIFF
--- a/frontend/components/App.styl
+++ b/frontend/components/App.styl
@@ -1,3 +1,7 @@
+html {
+  font-size: 16px;
+}
+
 body {
   font-family: sans-serif;
   margin: 0;
@@ -31,9 +35,14 @@ header {
 footer {
   border-top: 1px solid black;
   font-size: 2em;
-  position: absolute;
+  // position: absolute;
   bottom: 0;
   text-align: center;
+}
+
+form {
+  overflow: hidden;
+  margin-bottom: 1em;
 }
 
 label {

--- a/frontend/components/PerceivedDemographicQuestion.jsx
+++ b/frontend/components/PerceivedDemographicQuestion.jsx
@@ -1,44 +1,34 @@
 import React, { PropTypes } from 'react';
+import classNames from 'classnames';
 
 import strToId from '../utils/str-to-id';
+
+import RadioButtonOption from './RadioButtonOption';
 
 import styles from './PerceivedDemographics.styl';
 
 // ESLint didn't detect all props as being used without this destructuring...
 const PerceivedDemographicQuestion = ({
   className,
-  visible,
   name,
   options,
   onChange,
   selected,
 }) => (
-  <fieldset
-    className={`${className} ${styles.fieldset}`}
-    style={{
-      display: visible ? 'block' : 'none',
-    }}
-  >
+  <fieldset className={classNames(className, styles.fieldset)}>
     <legend>{name}</legend>
     {options.map((option) => {
       const optionKey = `${strToId(name)}_${strToId(option)}`;
       return (
-        <label
+        <RadioButtonOption
           key={optionKey}
-          className={styles.radioButton}
-          htmlFor={optionKey}
-        >
-          <input
-            id={optionKey}
-            type="radio"
-            name={name}
-            value={option}
-            onChange={onChange}
-            checked={option === selected}
-            required
-          />
-          {option}
-        </label>
+          id={optionKey}
+          name={name}
+          value={option}
+          checked={option === selected}
+          onChange={onChange}
+          required
+        />
       );
     })}
   </fieldset>
@@ -49,7 +39,6 @@ PerceivedDemographicQuestion.propTypes = {
   name: PropTypes.string.isRequired,
   options: PropTypes.arrayOf(PropTypes.string).isRequired,
   selected: PropTypes.string,
-  visible: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
 };
 

--- a/frontend/components/PerceivedDemographics.jsx
+++ b/frontend/components/PerceivedDemographics.jsx
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import classNames from 'classnames';
 
 import strToId from '../utils/str-to-id';
 import valuesChanged from '../utils/values-changed';
@@ -6,6 +7,8 @@ import valuesChanged from '../utils/values-changed';
 import * as propShapes from '../prop-shapes';
 
 import PerceivedDemographicQuestion from './PerceivedDemographicQuestion';
+import ProgressBar from './ProgressBar';
+import ProportionalContainer from './ProportionalContainer';
 
 import styles from './PerceivedDemographics.styl';
 
@@ -21,7 +24,6 @@ class PerceivedDemographics extends Component {
     this.handleInputChange = this.handleInputChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.prevStep = this.prevStep.bind(this);
-    this.nextStep = this.nextStep.bind(this);
   }
 
   componentDidMount() {
@@ -72,6 +74,7 @@ class PerceivedDemographics extends Component {
   }
 
   handleSubmit(event) {
+    console.log('Submitted!');
     event.preventDefault();
     this.props.onSubmit(this.prepareAnnotationsObject());
     if (this.props.current >= this.props.total) {
@@ -90,28 +93,33 @@ class PerceivedDemographics extends Component {
     });
   }
 
-  nextStep() {
-    // pull currentStep out of this.state to compute next step,
-    // and questionOrder out of this.props to compute max step
-    this.setState(({ currentStep }, { questionOrder }) => {
-      const nextStep = currentStep + 1;
-      const maxStep = questionOrder.length;
-      return {
-        // Prevent out-of-bounds nextStep value
-        currentStep: nextStep > maxStep ? maxStep : nextStep,
-      };
-    });
-  }
-
   render() {
     const { currentStep } = this.state;
-    const { demographicAttributes, questionOrder } = this.props;
-    window.props = this.props;
+    const {
+      demographicAttributes,
+      questionOrder,
+      current: currentImage,
+      total: totalImages,
+    } = this.props;
     return (
       <div>
-        <img
-          src={this.props.image && this.props.image.url}
-          alt="A face to label with perceived demographic information"
+        <ProportionalContainer maxWidth="500px" widthHeightRatio={1}>
+          <img
+            src={this.props.image && this.props.image.url}
+            alt="A face to label with perceived demographic information"
+          />
+        </ProportionalContainer>
+        <ProgressBar
+          className={styles.progressBar}
+          incrementName="Image"
+          current={currentImage}
+          total={totalImages}
+        />
+        <ProgressBar
+          className={styles.progressBar}
+          incrementName="Step"
+          current={currentStep + 1}
+          total={questionOrder.length}
         />
         <form onSubmit={this.handleSubmit}>
           {questionOrder.map((questionName, idx) => {
@@ -119,10 +127,10 @@ class PerceivedDemographics extends Component {
             return (
               <PerceivedDemographicQuestion
                 key={`question_${strToId(name)}_${id}`}
+                className={currentStep !== idx ? styles.hidden : ''}
                 name={name}
                 options={options}
                 selected={this.state[name]}
-                visible={currentStep === idx}
                 onChange={this.handleInputChange}
               />
             );
@@ -142,32 +150,20 @@ class PerceivedDemographics extends Component {
             </div>
           ) : null}
 
-          <div className={styles.carousel}>
+          {currentStep !== 0 ? (
             <button
               className={styles.prev}
               type="button"
               onClick={this.prevStep}
             >Back</button>
+          ) : null}
 
-            <span className={styles.current}>
-              Step {currentStep + 1} of {questionOrder.length};
-              {' '}
-              Image {this.props.current} of {this.props.total}
-            </span>
-
-            {currentStep < questionOrder.length ? (
-              <button
-                className={styles.next}
-                type="button"
-                onClick={this.nextStep}
-              >Next Step</button>
-            ) : (
-              <button
-                className={`${styles.next} ${styles.save}`}
-                type="submit"
-              >Submit</button>
-            )}
-          </div>
+          <button
+            className={classNames(styles.save, {
+              [styles.hidden]: currentStep < questionOrder.length,
+            })}
+            type="submit"
+          >Submit Annotations</button>
         </form>
       </div>
     );

--- a/frontend/components/PerceivedDemographics.styl
+++ b/frontend/components/PerceivedDemographics.styl
@@ -1,37 +1,20 @@
 @import './shared/mixins.styl';
 
-label {
-  display: block;
-  margin: 10px 0px;
-}
-
-.radioButton {
-  text-transform: capitalize;
-}
-
-.carousel {
+.progressBar {
   margin: 0.5em 0;
-  width: 100%;
-  text-align: center;
 }
+
 .prev,
-.current,
-.next {
-  display: inline-block;
-  text-align: center;
-}
-.prev,
-.next {
-  padding: 5px 10px;
-  border: 1px solid grey;
-  background-color: #ececec;
+.save {
+  button();
 }
 .prev {
   float: left;
 }
-.next {
+.save {
   float: right;
 }
+
 .hidden {
   visually-hidden();
 }

--- a/frontend/components/PerceivedDemographics.styl
+++ b/frontend/components/PerceivedDemographics.styl
@@ -1,3 +1,5 @@
+@import './shared/mixins.styl';
+
 label {
   display: block;
   margin: 10px 0px;
@@ -29,4 +31,7 @@ label {
 }
 .next {
   float: right;
+}
+.hidden {
+  visually-hidden();
 }

--- a/frontend/components/ProgressBar.jsx
+++ b/frontend/components/ProgressBar.jsx
@@ -1,0 +1,46 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+import styles from './ProgressBar.styl';
+
+const ProgressBar = ({
+  className,
+  incrementName,
+  current,
+  total,
+}) => {
+  const complete = current - 1;
+  const widthPct = (100 / total) * complete;
+  return (
+    <div className={classNames(className, styles.barContainer)}>
+      <span className={styles.label}>
+        {incrementName} {current} of {total}
+      </span>
+      <div
+        className={classNames(styles.bar, {
+          // Add a class to apply smooth transitions after the first step
+          [styles.inProgress]: complete > 0,
+        })}
+        style={{
+          width: `${widthPct}%`,
+        }}
+      />
+    </div>
+  );
+};
+
+ProgressBar.propTypes = {
+  className: PropTypes.string,
+  // e.g. "Step" or "Image"
+  incrementName: PropTypes.string.isRequired,
+  // "current" starts at 1
+  current: PropTypes.number.isRequired,
+  // Total item count
+  total: PropTypes.number.isRequired,
+};
+
+ProgressBar.defaultProps = {
+  className: '',
+};
+
+export default ProgressBar;

--- a/frontend/components/ProgressBar.styl
+++ b/frontend/components/ProgressBar.styl
@@ -1,0 +1,20 @@
+@import './shared/mixins.styl';
+
+.label {
+  visually-hidden();
+}
+
+.barContainer {
+  height: 5px;
+  width: 100%;
+  border: 1px solid #444;
+}
+
+.bar {
+  height: 5px;
+  background: #222;
+}
+
+.inProgress {
+  transition: width 200ms;
+}

--- a/frontend/components/ProportionalContainer.jsx
+++ b/frontend/components/ProportionalContainer.jsx
@@ -1,0 +1,43 @@
+import React, { PropTypes } from 'react';
+
+import styles from './ProportionalContainer.styl';
+
+function computeMaxHeight(maxWidth, widthHeightRatio) {
+  // Pull out the suffix,
+  const suffix = maxWidth.trim().replace(/^\d+(\.\d*)?/, '');
+  // And pull out the numeric value
+  const maxWidthValue = +(maxWidth.trim().replace(/[^\d]*$/, ''));
+  // Calculate and return a proportional height using the same units
+  return `${maxWidthValue / widthHeightRatio}${suffix}`;
+}
+
+const ProportionalContainer = ({
+  children,
+  maxWidth,
+  widthHeightRatio,
+}) => (
+  <div style={{ maxWidth }}>
+    <div
+      className={styles.container}
+      style={{
+        paddingBottom: `${100 / widthHeightRatio}%`,
+      }}
+    >
+      {children}
+    </div>
+  </div>
+);
+
+console.log(computeMaxHeight('500px', 4 / 3));
+
+ProportionalContainer.propTypes = {
+  children: PropTypes.node.isRequired,
+  maxWidth: PropTypes.string,
+  widthHeightRatio: PropTypes.number.isRequired,
+};
+
+ProportionalContainer.defaultProps = {
+  maxWidth: '100%',
+};
+
+export default ProportionalContainer;

--- a/frontend/components/ProportionalContainer.styl
+++ b/frontend/components/ProportionalContainer.styl
@@ -1,0 +1,12 @@
+.container {
+  position: relative;
+  width: 100%;
+  height: 0;
+
+  > * {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    left: 0;
+  }
+}

--- a/frontend/components/RadioButtonOption.jsx
+++ b/frontend/components/RadioButtonOption.jsx
@@ -1,0 +1,45 @@
+import React, { PropTypes } from 'react';
+
+import styles from './RadioButtonOption.styl';
+
+const RadioButtonOption = ({
+  id,
+  name,
+  value,
+  checked,
+  required,
+  onChange,
+}) => (
+  <label
+    className={styles.radioButton}
+    htmlFor={id}
+  >
+    <input
+      className={styles.hidden}
+      id={id}
+      type="radio"
+      name={name}
+      value={value}
+      checked={checked}
+      onChange={onChange}
+      required={required}
+    />
+    {value}
+  </label>
+);
+
+RadioButtonOption.propTypes = {
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  checked: PropTypes.bool.isRequired,
+  required: PropTypes.bool,
+  onChange: PropTypes.func.isRequired,
+};
+
+RadioButtonOption.defaultProps = {
+  selected: '',
+  required: false,
+};
+
+export default RadioButtonOption;

--- a/frontend/components/RadioButtonOption.styl
+++ b/frontend/components/RadioButtonOption.styl
@@ -1,0 +1,13 @@
+@import './shared/mixins.styl';
+
+.radioButton {
+  button();
+
+  margin: 10px 0px;
+  display: block;
+  text-align: left;
+}
+
+.hidden {
+  visually-hidden();
+}

--- a/frontend/components/shared/mixins.styl
+++ b/frontend/components/shared/mixins.styl
@@ -5,3 +5,29 @@ visually-hidden() {
   clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
   clip: rect(1px, 1px, 1px, 1px);
 }
+
+button() {
+  display: inline-block;
+  height: 3em;
+  padding: 0 20px;
+  color: #333;
+  font-size: 0.8em;
+  text-align: center;
+  line-height: 3em;
+  font-weight: 600;
+  text-transform: capitalize;
+  text-decoration: none;
+  white-space: nowrap;
+  background-color: transparent;
+  border-radius: 4px;
+  border: 1px solid #bbb;
+  cursor: pointer;
+  box-sizing: border-box;
+
+  &:hover,
+  &:focus {
+    color: black;
+    border-color: #666;
+    outline: 0;
+  }
+}

--- a/frontend/components/shared/mixins.styl
+++ b/frontend/components/shared/mixins.styl
@@ -1,0 +1,7 @@
+visually-hidden() {
+  position: absolute !important;
+  height: 1px; width: 1px;
+  overflow: hidden;
+  clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+  clip: rect(1px, 1px, 1px, 1px);
+}

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "body-parser": "^1.16.1",
     "careen": "^0.1.1",
     "chalk": "^1.1.3",
+    "classnames": "^2.2.5",
     "connect-pg-simple": "^3.1.2",
     "cookie-parser": "^1.4.3",
     "debug": "^2.6.1",


### PR DESCRIPTION
- No longer possible to skip a step
- Convert radio buttons to things that look visually like buttons
- Use visual hiding, not display:none, for better accessibility
- Convert "X of Y" callouts into progress bar components
- Implement fixed proportional scaling of the image
- Introduce a mixins stylus file for code sharing

Demo:

![new-form-flow](https://cloud.githubusercontent.com/assets/442115/24060883/934a756a-0b2b-11e7-8d44-b59170378992.gif)
