### PR TITLE
Resolve lint issues & update to reverted latest eslint react plugin tag

### DIFF
--- a/backend/base/controller.js
+++ b/backend/base/controller.js
@@ -41,7 +41,7 @@ function formatLink(urlPath, query, params) {
   return `${urlPath}?${stringify(linkQuery)}`;
 }
 
-export const makeLinks = function(metadata, req) {
+export function makeLinks(metadata, req) {
   const links = {};
   const {
     page,
@@ -66,7 +66,7 @@ export const makeLinks = function(metadata, req) {
     }
   }
   return links;
-};
+}
 
 export function setLinkHeader(links, req, res) {
   const linkChunks = Object.keys(links).map((link) => {
@@ -168,7 +168,7 @@ export function makeDestroyer(model) {
  * element will get a copy of each mapped param.
  */
 export function injectParams(paramMap) {
-  return function(req, res, next) {
+  return (req, res, next) => {
     const data = (req.body && req.body.data) || {};
     Object.keys(paramMap).forEach((paramKey) => {
       const paramValue = req.params[paramKey];

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "eslint-loader": "^1.6.3",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^3.0.2",
-    "eslint-plugin-react": "6.9.0",
+    "eslint-plugin-react": "^6.10.3",
     "file-loader": "^0.9.0",
     "find-cache-dir": "^0.1.1",
     "hard-source-webpack-plugin": "^0.3.8",


### PR DESCRIPTION
At the end of last week a new release of `eslint-plugin-react` was pushed out, unintentionally introducing a new setting that caused a breaking change. A fix was just pushed up to NPM, and updating to today's latest version resolves the issue. The maintainer has acknowledged the issue and intends to avoid similar problems going forward, so I chose to bump the dependency and reintroduce a ^ version range rather than leaving it pinned. If this bites us again we can reverse course and lock everything down!

This also fixes two unnamed-function warnings in the base controller, which have been lingering for a while -- seemed like a good time to tackle them.