### PR TITLE
Consistently specify Node version support, and improve Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: node_js
 
-script: "npm test"
-
-env:
-- CI=1
-
 node_js:
   - "7"
   - "6"
-  - "5"
+
+before_install:
+  - npm prune
+  - npm update
+
+cache:
+  directories:
+    - node_modules
 
 sudo: false

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "1.0.0",
   "private": true,
   "license": "MIT",
+  "engines": {
+    "node": ">=6.6.0"
+  },
   "browserslist": [
     "> 5%",
     "last 2 versions"


### PR DESCRIPTION
The new keys in .travis.yml should improve build times.

CI flag is removed because it is no longer used to affect test behavior.

Node engine support specified as "my development version and up" in package.json,

and Node 5 removed from Travis config.