### PR TITLE
Reuse already annotated images

### DIFF
--- a/api.md
+++ b/api.md
@@ -42,7 +42,7 @@ Prior to session enrollment this endpoint returns a JSON workload of 12 random i
   ]
 }]"
 ```
-Session enrollment occurs when an active session successfully annotates 12 images, and gets the 8 hidden known ground truths right. Once a session has successfully posted 12 annotated images back to the api and gotten the 8 hidden known ground truths correct, the session is considered enrolled, and all future requests from that session receive a response with a workload of 3 images containing 2 known and 1 unknown image.
+Session enrollment occurs when an active session successfully annotates 12 images, and gets the 8 hidden known ground truths right. Once a session has successfully posted 12 annotated images back to the api and gotten the 8 hidden known ground truths correct, the session is considered enrolled, and all future requests from that session receive a response with a workload of 3 images containing 2 known and 1 unknown image.  The images will be the "least annotated" by the current user, meaning it will not reuse any image until you've completed all the knowns.
 
 ### post /api/annotations
 Expects the following JSON post:

--- a/backend/endpoints/annotations/queries/getImages.sql
+++ b/backend/endpoints/annotations/queries/getImages.sql
@@ -36,7 +36,7 @@ annotator as (
   GROUP BY image_id
 ),
 -- Look for images, calculate if we can use them as knowns
--- restrict the images we've annotated, and randomize order
+-- sort the images we've alread annotated to be last, and randomize order
 truth_table as (
   SELECT
     image.id,
@@ -49,9 +49,8 @@ truth_table as (
     LEFT JOIN known_count known on image.id = known.image_id
     LEFT JOIN annotator on image.id = annotator.image_id,
     attributes
-  WHERE
-    annotator.count is null
-  ORDER BY RANDOM()
+  ORDER BY annotator.count NULLS FIRST,
+    RANDOM()
 ),
 -- Select the first "8" (2/3's of the limit) known images
 truths as (


### PR DESCRIPTION
Small SQL tweak which now orders all the images based on how many annotations the annotator has done for each image, which allows the small number of "knowns" to be constantly recycled if need be.

Relates to #104 