### PR TITLE
configure nginx

### DIFF
--- a/ansible/provision.yml
+++ b/ansible/provision.yml
@@ -14,6 +14,10 @@
       systemd:
         name: postgresql
         state: restarted
+    - name: restart nginx
+      systemd:
+        name: nginx
+        state: restarted
   tasks:
     # Start decrypting secrets (if we need them).
     - include_vars:
@@ -134,24 +138,20 @@
       file:
         path: /etc/nginx/sites-enabled/default
         state: absent
+      notify: restart nginx
 
     - name: ensure nginx is configured
       template:
         src: nginx.conf.j2
         dest: /etc/nginx/sites-enabled/site.conf
+      notify: restart nginx
 
     - name: ensure htpasswd is configured
       template:
         src: htpasswd.j2
         dest: /etc/nginx/htpasswd
       when: "{{basic_auth}}"
-
-    # todo verify nginx config here
-
-    - name: ensure nginx is restarted
-      systemd:
-        name: nginx
-        state: restarted
+      notify: restart nginx
     # End managing nginx.
 
     # Start managing PostgreSQL.

--- a/ansible/templates/nginx.conf.j2
+++ b/ansible/templates/nginx.conf.j2
@@ -18,6 +18,10 @@ server {
     include proxy_params;
     proxy_pass http://api;
   }
+  location ~* \.(css|js) {
+    expires max;
+    break;
+  }
 }
 
 {% if env == 'production' %}

--- a/ansible/templates/nginx.conf.j2
+++ b/ansible/templates/nginx.conf.j2
@@ -22,6 +22,26 @@ server {
     expires max;
     break;
   }
+  gzip on;
+  gzip_vary on;
+  gzip_disable "MSIE [1-6]\.";
+  gzip_comp_level 6;
+  gzip_min_length 1100;
+  gzip_buffers 16 8k;
+  gzip_proxied any;
+  gzip_proxied expired no-cache no-store private auth;
+  gzip_types
+      text/plain
+      text/css
+      text/js
+      text/xml
+      text/javascript
+      application/javascript
+      application/x-javascript
+      application/json
+      application/xml
+      application/rss+xml
+      image/svg+xml;
 }
 
 {% if env == 'production' %}

--- a/ansible/templates/nginx.conf.j2
+++ b/ansible/templates/nginx.conf.j2
@@ -44,7 +44,7 @@ server {
       image/svg+xml;
 }
 
-{% if env == 'production' %}
+{% if env != 'development' %}
 server {
   listen 80 default_server;
   server_name _;

--- a/ansible/templates/nginx.conf.j2
+++ b/ansible/templates/nginx.conf.j2
@@ -48,6 +48,6 @@ server {
 server {
   listen 80 default_server;
   server_name _;
-  return 301 https://{{fqdn}}$request_uri;
+  return 301 http://{{fqdn}}$request_uri;
 }
 {% endif %}


### PR DESCRIPTION
This adds some missing config and closes gh-114 and gh-123.

Verification can happy locally by doing the following:
```
npm run provision:vagrant
npm run deploy:vagrant
```

Gzip and far-future expirations can be tested thusly:
```
curl -H "Accept-Encoding: gzip" -I http://10.10.0.100/bundle.js"
```

The response headers should include:
```
Expires: Thu, 31 Dec 2037 23:55:55 GMT
Cache-Control: max-age=315360000
Content-Encoding: gzip
```

Once landed, the following needs to be run:
```
npm run provision:production
npm run provision:staging
```