### PR TITLE
Add content hashes to js and css distribution files

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -16,7 +16,7 @@ module.exports = {
 
   output: {
     // the output bundle
-    filename: 'bundle.min.js',
+    filename: '[name]-[hash].min.js',
 
     path: resolve(__dirname, 'dist'),
   },
@@ -88,7 +88,7 @@ module.exports = {
     }),
 
     // Extract css into bundle.css
-    new ExtractTextPlugin('bundle.css'),
+    new ExtractTextPlugin('[name]-[contenthash].css'),
 
     // Minify with UglifyJS
     new webpack.optimize.UglifyJsPlugin({


### PR DESCRIPTION
Close #127

Use webpack options to add hashes of the content of js and css output
files.

Along with the hashes the names are included. So the main js bundle is
main-<hash>.js. Same for the css. With those hashes we could opt for
abbreviated ones.

A further thing we can do is modify url-loader for its file-loader fallback. The file-loader default names are just content hashes. We can add the file name so it'll be fancy-image-<hash>.png for example.