### PR TITLE
Implement UI feedback for workload completion progression

### DIFF
--- a/api.md
+++ b/api.md
@@ -22,8 +22,8 @@ returns a JSON list of possible annotation types, eg:
 ### get /api/annotations/workload
 Prior to session enrollment this endpoint returns a JSON workload of 12 random images to be annotated (with 8 known and 4 unknown images randomly interspersed), eg:
 
-```
-"[{
+```js
+[{
   "id":2,
   "images":[
     {
@@ -38,9 +38,11 @@ Prior to session enrollment this endpoint returns a JSON workload of 12 random i
       "width":250,
       "height":250
     }
-    ... {12th image object}
-  ]
-}]"
+    // ... {12th image object}
+  ],
+  // The user has completed 2 previous workloads
+  "completeCount": 2
+}]
 ```
 Session enrollment occurs when an active session successfully annotates 12 images, and gets the 8 hidden known ground truths right. Once a session has successfully posted 12 annotated images back to the api and gotten the 8 hidden known ground truths correct, the session is considered enrolled, and all future requests from that session receive a response with a workload of 3 images containing 2 known and 1 unknown image.  The images will be the "least annotated" by the current user, meaning it will not reuse any image until you've completed all the knowns.
 

--- a/backend/db/migrations/j0ttjlsg.count-workloads.sql
+++ b/backend/db/migrations/j0ttjlsg.count-workloads.sql
@@ -1,0 +1,5 @@
+ALTER TABLE workload
+  ADD complete_count INT;
+---
+ALTER TABLE workload
+  DROP complete_count;

--- a/backend/endpoints/annotations/controller.js
+++ b/backend/endpoints/annotations/controller.js
@@ -30,10 +30,11 @@ export function getWorkload(req, res) {
   // prior storeWorload query
   .then((workloads) => {
     const response = workloads.map((workload) => {
+      const { id, complete_count: completeCount } = workload;
       const images = workload.images.map(
         image => omit(image, 'is_known')
       );
-      return { ...workload, images };
+      return { id, images, completeCount };
     });
 
     res.send(response);

--- a/backend/endpoints/annotations/queries/storeWorkload.sql
+++ b/backend/endpoints/annotations/queries/storeWorkload.sql
@@ -1,3 +1,13 @@
-INSERT INTO workload (annotator_id, images)
-VALUES (${annotatorId}, ${images:json})
-RETURNING id, images
+WITH previous_work AS (
+  SELECT count(*) as complete_count
+    FROM workload
+  WHERE annotator_id = ${annotatorId}
+    AND NOT(score IS NULL)
+)
+INSERT INTO workload (annotator_id, images, complete_count)
+SELECT
+  ${annotatorId} as annotator_id,
+  ${images:json} as images,
+  complete_count
+FROM previous_work
+RETURNING id, images, complete_count

--- a/frontend/components/ModalContainer.jsx
+++ b/frontend/components/ModalContainer.jsx
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 
 import { isLoading, appErrors } from '../redux/selectors';
-import errorPropsService from '../services/error-props';
+import { errorProps } from '../services/content';
 
 import LoadingIndicator from './Overlays/Loading';
 import Modal from './Overlays/Modal';
@@ -16,7 +16,7 @@ const getErrorProps = (errors) => {
   const err = errors[0];
 
   return {
-    ...errorPropsService(err.type),
+    ...errorProps(err.type),
     errorMessage: err.error && err.error.message,
     retryAction: err.retryAction,
   };

--- a/frontend/components/PerceivedDemographics.jsx
+++ b/frontend/components/PerceivedDemographics.jsx
@@ -9,6 +9,7 @@ import * as propShapes from '../prop-shapes';
 import PerceivedDemographicQuestion from './PerceivedDemographicQuestion';
 import ProgressBar from './ProgressBar';
 import ProportionalContainer from './ProportionalContainer';
+import ProgressFeedbackContainer from './ProgressFeedback/ProgressFeedback';
 
 import styles from './PerceivedDemographics.styl';
 
@@ -120,6 +121,7 @@ class PerceivedDemographics extends Component {
           current={currentStep + 1}
           total={questionOrder.length}
         />
+        <ProgressFeedbackContainer show={currentStep === 0} />
         <form onSubmit={this.handleSubmit}>
           {questionOrder.map((questionName, idx) => {
             const { id, name, options } = demographicAttributes[questionName];

--- a/frontend/components/ProgressFeedback/ProgressFeedback.jsx
+++ b/frontend/components/ProgressFeedback/ProgressFeedback.jsx
@@ -1,0 +1,30 @@
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+import { onFirstImage, completedWorkloadCount } from '../../redux/selectors';
+import { workloadFeedback } from '../../services/content';
+
+import styles from './ProgressFeedback.styl';
+
+const ProgressFeedback = ({ message, show }) => {
+  if (! show || ! message) {
+    return null;
+  }
+  return (
+    <p className={styles.uxFeedback}>
+      {message}
+    </p>
+  );
+};
+
+ProgressFeedback.propTypes = {
+  message: PropTypes.string.isRequired,
+  show: PropTypes.bool.isRequired,
+};
+
+const mapStateToProps = (state, props) => ({
+  message: workloadFeedback(completedWorkloadCount(state)),
+  show: props.show && onFirstImage(state),
+});
+
+export default connect(mapStateToProps)(ProgressFeedback);

--- a/frontend/components/ProgressFeedback/ProgressFeedback.styl
+++ b/frontend/components/ProgressFeedback/ProgressFeedback.styl
@@ -1,0 +1,5 @@
+.uxFeedback {
+  font-style: italic;
+  font-weight: bold;
+  padding: 4px 12px;
+}

--- a/frontend/redux/__tests__/selectors.test.js
+++ b/frontend/redux/__tests__/selectors.test.js
@@ -254,7 +254,7 @@ describe('selector functions', () => {
     it('returns true when on the first image in a workload', () => {
       expect(onFirstImage({
         workload: {
-          todo: [ 1, 2 ],
+          todo: [1, 2],
           complete: [],
         },
       })).toBe(true);
@@ -263,8 +263,8 @@ describe('selector functions', () => {
     it('returns false on subsequent workload steps', () => {
       expect(onFirstImage({
         workload: {
-          todo: [ 2 ],
-          complete: [ 1 ],
+          todo: [2],
+          complete: [1],
         },
       })).toBe(false);
     });

--- a/frontend/redux/__tests__/selectors.test.js
+++ b/frontend/redux/__tests__/selectors.test.js
@@ -224,4 +224,51 @@ describe('selector functions', () => {
     });
   });
 
+  describe('completedWorkloadCount', () => {
+    const { completedWorkloadCount } = selectors;
+
+    it('is a function', () => {
+      expect(completedWorkloadCount).toBeDefined();
+      expect(completedWorkloadCount).toBeInstanceOf(Function);
+    });
+
+    it('returns a count of workloads a user has completed in their session', () => {
+      expect(completedWorkloadCount({
+        workload: {
+          faces: true,
+          completeCount: 4,
+        },
+      })).toBe(4);
+    });
+
+  });
+
+  describe('onFirstImage', () => {
+    const { onFirstImage } = selectors;
+
+    it('is a function', () => {
+      expect(onFirstImage).toBeDefined();
+      expect(onFirstImage).toBeInstanceOf(Function);
+    });
+
+    it('returns true when on the first image in a workload', () => {
+      expect(onFirstImage({
+        workload: {
+          todo: [ 1, 2 ],
+          complete: [],
+        },
+      })).toBe(true);
+    });
+
+    it('returns false on subsequent workload steps', () => {
+      expect(onFirstImage({
+        workload: {
+          todo: [ 2 ],
+          complete: [ 1 ],
+        },
+      })).toBe(false);
+    });
+
+  });
+
 });

--- a/frontend/redux/reducers/__tests__/workload.test.js
+++ b/frontend/redux/reducers/__tests__/workload.test.js
@@ -17,6 +17,7 @@ describe('workload reducer', () => {
       todo: [],
       byId: {},
       complete: [],
+      completeCount: 0,
     });
   });
 
@@ -54,6 +55,7 @@ describe('workload reducer', () => {
         { id: 1998, url: '0003.jpg', width: 250, height: 250 },
         { id: 991, url: '0004.jpg', width: 250, height: 250 },
       ],
+      completeCount: 3,
     }];
 
     it('populates the workload ID', () => {
@@ -65,6 +67,17 @@ describe('workload reducer', () => {
       expect(nextState.id).toBeDefined();
       expect(nextState.id).not.toBe(initialState.id);
       expect(nextState.id).toBe(121);
+    });
+
+    it('updates the workload completeCount', () => {
+      const nextState = workloadReducer(initialState, {
+        type: RECEIVE_WORKLOAD,
+        payload,
+      });
+      expect(nextState).not.toBe(initialState);
+      expect(nextState.completeCount).toBeDefined();
+      expect(nextState.completeCount).not.toBe(initialState.completeCount);
+      expect(nextState.completeCount).toBe(3);
     });
 
     it('populates the byId dictionary', () => {

--- a/frontend/redux/reducers/workload.js
+++ b/frontend/redux/reducers/workload.js
@@ -62,9 +62,20 @@ function complete(state = [], action) {
   }
 }
 
+function completeCount(state = 0, action) {
+  switch (action.type) {
+  case RECEIVE_WORKLOAD:
+    return action.payload[0].completeCount;
+
+  default:
+    return state;
+  }
+}
+
 export default combineReducers({
   id,
   todo,
   byId,
   complete,
+  completeCount,
 });

--- a/frontend/redux/selectors.js
+++ b/frontend/redux/selectors.js
@@ -25,3 +25,8 @@ export const demographicAttributesOrder = state => state.demographicAttributes.o
 export const imageAnnotations = state => state.annotations;
 
 export const appErrors = state => state.errors;
+
+export const completedWorkloadCount = state => state.workload.completeCount;
+
+export const onFirstImage = state =>
+  state.workload.todo.length && ! state.workload.complete.length;

--- a/frontend/services/content.js
+++ b/frontend/services/content.js
@@ -7,7 +7,7 @@
  */
 import * as actions from '../redux/actions';
 
-export default function(type) {
+export function errorProps(type) {
   switch (type) {
   case actions.REQUEST_ATTRIBUTES_FAILED:
     return {
@@ -35,4 +35,23 @@ export default function(type) {
       confirmText: 'OK',
     };
   }
+}
+
+export function workloadFeedback(count) {
+  if (count === 0) {
+    return 'Welcome! This is your first batch of images.';
+  }
+  if (count === 1) {
+    return 'You\'ve completed your first batch—great!';
+  }
+  if (count === 2) {
+    return 'You\'re a champ!';
+  }
+  if (count === 3) {
+    return 'You\'re on fire!';
+  }
+  if (count % 10) {
+    return '';
+  }
+  return `You've completed ${count} batches! Amazing!`;
 }


### PR DESCRIPTION
Closes #74

This implements an interface that shows an annotator encouraging messages as they complete more workloads. The implementation is driven by a new `completeCount` field provided on the Workload API response; on the first step of a new workload (_i.e._, the first image in a workload AND the first annotation step for that image), a predetermined message is displayed to the annotator depending on their progress.

Current messages are for:

- Starting your first workload
- Completing your first workload
- Completing your second workload
- Completing your third workload
- Completing any multiple of 10 workloads

The copy should be considered placeholder, but I did try to avoid using the actual term "workload," as I felt it connotes that we were placing a job or a burden on the annotator. Not sure what's best here.

In action:

![ux-feedback-demonstration](https://cloud.githubusercontent.com/assets/442115/24468178/6df3f6ac-1485-11e7-9034-e497381e0019.gif)