### PR TITLE
Configure NODE_ENV to "production" when building prod bundle

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -87,6 +87,13 @@ module.exports = {
       template: './index.html',
     }),
 
+    // Set NODE_ENV to production so that Uglify can strip out dev-only code
+    new webpack.DefinePlugin({
+      'process.env': {
+        'NODE_ENV': JSON.stringify('production'),
+      },
+    }),
+
     // Extract css into bundle.css
     new ExtractTextPlugin('[name]-[contenthash].css'),
 

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -90,7 +90,7 @@ module.exports = {
     // Set NODE_ENV to production so that Uglify can strip out dev-only code
     new webpack.DefinePlugin({
       'process.env': {
-        'NODE_ENV': JSON.stringify('production'),
+        NODE_ENV: JSON.stringify('production'),
       },
     }),
 


### PR DESCRIPTION
When we build our production bundle, this is what we get:
```
                                        Asset       Size  Chunks                    Chunk Names
             main-cb910c189f1405adaf68.min.js     448 kB       0  [emitted]  [big]  main
    main-70a302a379274539c79d313d674f80b0.css     8.8 kB       0  [emitted]         main
main-70a302a379274539c79d313d674f80b0.css.map  118 bytes       0  [emitted]         main
                                   index.html  544 bytes          [emitted]
   [8] ../~/react/react.js 56 bytes {0} [built]
```
Not bad, but we can do better. A lot of code within React (and some within our own app, such as the store logging middleware) is gated by a check that NODE_ENV !== "production"; we can use the DefinePlugin to hard-code that value before Uglify runs, so that any gated code can be removed entirely.
```
                                        Asset       Size  Chunks                    Chunk Names
             main-48877c14f225d936c25a.min.js     366 kB       0  [emitted]  [big]  main
    main-70a302a379274539c79d313d674f80b0.css     8.8 kB       0  [emitted]         main
main-70a302a379274539c79d313d674f80b0.css.map  118 bytes       0  [emitted]         main
                                   index.html  544 bytes          [emitted]
```
18% smaller!