### PR TITLE
Output a sourcemap file for the production build

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -92,6 +92,7 @@ module.exports = {
 
     // Minify with UglifyJS
     new webpack.optimize.UglifyJsPlugin({
+      sourceMap: true,
       compress: {
         warnings: false,
       },


### PR DESCRIPTION
Our production Webpack configuration was set up to generate a sourcemap file, but Uglify was preventing it from being output. Setting Uglify's "sourceMap" option to `true` allows this file to be generated as part of the build, which could aid in live debugging in production.