### PR TITLE
Implement Global Annotation Progress on Home

### DIFF
--- a/backend/endpoints/annotations/controller.js
+++ b/backend/endpoints/annotations/controller.js
@@ -9,6 +9,11 @@ export function getAttributes(req, res) {
     .then(data => res.send(data));
 }
 
+export function getOverallStats(req, res) {
+  db.query(queries.getOverallStats)
+    .then(data => res.send(data));
+}
+
 export function getWorkload(req, res) {
   // First time users see 8 truths, 4 new images.
   // Every workload after the first should get 2 truths, 1 new image.

--- a/backend/endpoints/annotations/queries/getOverallStats.sql
+++ b/backend/endpoints/annotations/queries/getOverallStats.sql
@@ -1,0 +1,6 @@
+SELECT
+  count(DISTINCT a.image_id) AS annotated_count,
+  count(DISTINCT i.id) AS total_count
+FROM
+  image i
+  LEFT JOIN image_annotation a ON a.image_id = i.id

--- a/backend/endpoints/annotations/routes.js
+++ b/backend/endpoints/annotations/routes.js
@@ -12,6 +12,9 @@ export const routes = {
       session.ensureSession,
       controller.getWorkload,
     ],
+    '/overall-stats': [
+      controller.getOverallStats,
+    ],
   },
   post: {
     '/': [

--- a/frontend/components/Home.jsx
+++ b/frontend/components/Home.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
+import KnownOverallProgressContainer from './KnownOverallProgressContainer';
+
 export default () => (
   <div>
     <h1>The Computer Vision Benchmarking Project</h1>
@@ -18,5 +20,6 @@ export default () => (
       <Link to="/Landmarks">outlining features</Link> of the faces in our curated
       database of pictures of public domain faces.
     </p>
+    <KnownOverallProgressContainer />
   </div>
 );

--- a/frontend/components/KnownOverallProgress.jsx
+++ b/frontend/components/KnownOverallProgress.jsx
@@ -1,0 +1,42 @@
+import React, { PropTypes } from 'react';
+
+import styles from './KnownOverallProgress.styl';
+
+const LOADING_IMAGES = '...';
+const LOADING_ANNOTATED = '...';
+
+const KnownOverallProgress = ({
+  annotated,
+  images,
+  loadOverallStats,
+}) => {
+  const hasImages = images > -1;
+  const hasAnnontated = annotated > -1;
+  if (hasAnnontated === false) {
+    loadOverallStats();
+  }
+  let progress = 0;
+  if (hasAnnontated && hasImages) {
+    progress = annotated / images;
+  }
+  return (<div>
+    <p>
+      We currently have {hasImages ? images : LOADING_IMAGES} images with data
+      on {hasAnnontated ? annotated : LOADING_ANNOTATED} of them.
+    </p>
+    <progress className={styles.progress} value={progress} min="0" max="100" />
+  </div>);
+};
+
+KnownOverallProgress.propTypes = {
+  annotated: PropTypes.number,
+  images: PropTypes.number,
+  loadOverallStats: PropTypes.func.isRequired,
+};
+
+KnownOverallProgress.defaultProps = {
+  annotated: undefined,
+  images: undefined,
+};
+
+export default KnownOverallProgress;

--- a/frontend/components/KnownOverallProgress.styl
+++ b/frontend/components/KnownOverallProgress.styl
@@ -1,0 +1,5 @@
+.progress {
+  appearance: none;
+  width: 50%;
+  height: 2em;
+}

--- a/frontend/components/KnownOverallProgressContainer.jsx
+++ b/frontend/components/KnownOverallProgressContainer.jsx
@@ -1,0 +1,15 @@
+import { connect } from 'react-redux';
+import { requestOverallStats } from '../redux/actions';
+import { overallAnnotated, overallImages } from '../redux/selectors';
+import KnownOverallProgress from './KnownOverallProgress';
+
+const mapStateToProps = state => ({
+  annotated: overallAnnotated(state),
+  images: overallImages(state),
+});
+
+const mapDispatchToProps = dispatch => ({
+  loadOverallStats: () => dispatch(requestOverallStats()),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(KnownOverallProgress);

--- a/frontend/redux/actions.js
+++ b/frontend/redux/actions.js
@@ -57,6 +57,30 @@ export const requestAttributesFailed = (error, retryAction) => ({
   error: true,
 });
 
+/** @prop {string} Action to start a simple request for the global "overall" stats */
+export const REQUEST_OVERALL_STATS = 'REQUEST_OVERALL_STATS';
+export const requestOverallStats = () => ({
+  type: REQUEST_OVERALL_STATS,
+});
+
+/** @prop {string} Action to place received global "overall" statistics in the store */
+export const RECEIVE_OVERALL_STATS = 'RECEIVE_OVERALL_STATS';
+export const receiveOverallStats = stats => ({
+  type: RECEIVE_OVERALL_STATS,
+  payload: stats,
+});
+
+/** @prop {string} Action to signal the overall stats data request failed */
+export const REQUEST_OVERALL_STATS_FAILED = 'REQUEST_OVERALL_STATS_FAILED';
+export const requestOverallStatsFailed = (error, retryAction) => ({
+  type: REQUEST_OVERALL_STATS_FAILED,
+  payload: {
+    error,
+    retryAction,
+  },
+  error: true,
+});
+
 export const SAVE_DEMOGRAPHIC_ANNOTATIONS = 'SAVE_DEMOGRAPHIC_ANNOTATIONS';
 export const saveDemographicAnnotations = ({ id, annotations }) => ({
   type: SAVE_DEMOGRAPHIC_ANNOTATIONS,

--- a/frontend/redux/reducers.js
+++ b/frontend/redux/reducers.js
@@ -4,6 +4,7 @@ import loading from './reducers/loading';
 import demographicAttributes from './reducers/demographic-attributes';
 import workload from './reducers/workload';
 import annotations from './reducers/annotations';
+import overallStats from './reducers/overall-stats';
 import errors from './reducers/errors';
 
 /*
@@ -20,6 +21,9 @@ export default combineReducers({
   workload,
   // The image annotations to be submitted to the server
   annotations,
+  // Global "overall" statistics so users can see global contribution to the
+  // project
+  overallStats,
   // The error reducer stores API errors and any viable actions
   // a user could take to resolve the error
   errors,

--- a/frontend/redux/reducers/overall-stats.js
+++ b/frontend/redux/reducers/overall-stats.js
@@ -1,0 +1,13 @@
+/**
+ * A reducer to manage global "overall" statistic on the site so users can see
+ * the global contribution to the project.
+ **/
+
+import { RECEIVE_OVERALL_STATS } from '../actions';
+
+export default (state = {}, action) => {
+  if (action.type === RECEIVE_OVERALL_STATS) {
+    return Object.assign({}, state, action.payload);
+  }
+  return state;
+};

--- a/frontend/redux/sagas.js
+++ b/frontend/redux/sagas.js
@@ -1,7 +1,13 @@
 import { call, fork, put, takeLatest, select } from 'redux-saga/effects';
-import { getAttributes, getWorkload, postWorkload } from '../services/api';
+import {
+  getAttributes,
+  getOverallStats,
+  getWorkload,
+  postWorkload,
+} from '../services/api';
 import {
   REQUEST_ATTRIBUTES, receiveAttributes, requestAttributesFailed,
+  REQUEST_OVERALL_STATS, receiveOverallStats, requestOverallStatsFailed,
   REQUEST_WORKLOAD, receiveWorkload, requestWorkloadFailed,
   COMPLETE_WORKLOAD, completeWorkloadFailed,
 } from './actions';
@@ -14,6 +20,16 @@ export function* requestAttributes(action) {
     yield put(receiveAttributes(anotatableAttributes));
   } catch (e) {
     yield put(requestAttributesFailed(e, action));
+  }
+}
+
+// worker Saga: will be fired on REQUEST_OVERALL_STATS actions
+export function* requestOverallStats(action) {
+  try {
+    const overallStats = yield call(getOverallStats);
+    yield put(receiveOverallStats(overallStats[0]));
+  } catch (e) {
+    yield put(requestOverallStatsFailed(e, action));
   }
 }
 
@@ -41,6 +57,7 @@ export function* completeWorkload(action) {
 export default function* rootSaga() {
   yield [
     fork(takeLatest, REQUEST_ATTRIBUTES, requestAttributes),
+    fork(takeLatest, REQUEST_OVERALL_STATS, requestOverallStats),
     fork(takeLatest, REQUEST_WORKLOAD, requestWorkload),
     fork(takeLatest, COMPLETE_WORKLOAD, completeWorkload),
   ];

--- a/frontend/redux/selectors.js
+++ b/frontend/redux/selectors.js
@@ -30,3 +30,6 @@ export const completedWorkloadCount = state => state.workload.completeCount;
 
 export const onFirstImage = state =>
   state.workload.todo.length && ! state.workload.complete.length;
+
+export const overallAnnotated = state => Number(state.overallStats.annotated_count);
+export const overallImages = state => Number(state.overallStats.total_count);

--- a/frontend/services/api.js
+++ b/frontend/services/api.js
@@ -17,3 +17,9 @@ export function getAttributes() {
     // Axios exposes JSON response body as .data property
     .then(result => result.data);
 }
+
+export function getOverallStats() {
+  return axios.get('/api/annotations/overall-stats')
+    // Axios exposes JSON response body as .data property
+    .then(result => result.data);
+}

--- a/frontend/services/content.js
+++ b/frontend/services/content.js
@@ -15,6 +15,12 @@ export function errorProps(type) {
       confirmText: 'Retry',
     };
 
+  case actions.REQUEST_OVERALL_STATS_FAILED:
+    return {
+      errorTitle: 'Global Statistics Load Error',
+      confirmText: 'Retry',
+    };
+
   case actions.REQUEST_WORKLOAD_FAILED:
     return {
       errorTitle: 'Data Load Error',


### PR DESCRIPTION
Closes #118.

- Add a `/annotations/overall-stats` api endpoint
- Add api services, redux actions and sagas for requesting `overall-stats`
- Add a KnownOverallProgress component and container
- Add KnownOverallProgress to Home

`overall-stats` currently returns `known_count` and `total_count`. With those two values we can add a basic progress bar with some information about the global progress of the project to the Home page. `overall-stats` with its name may also be a good place for us to expand the information of the projects progress.