### PR TITLE
make canonical domain ajl.ai - closes gh-149

### DIFF
--- a/ansible/inventory/production
+++ b/ansible/inventory/production
@@ -1,1 +1,1 @@
-ajl.bocoup.org env=production domain_list='["ajl.bocoup.org","fightbias.org","fightbias.io","ajl.ai"]'
+ajl.ai env=production domain_list='["ajl.ai","fightbias.org","fightbias.io","ajl.bocoup.org"]'


### PR DESCRIPTION
This requires running `npm run provision:production` (which I have done--this change is currently live).