### PR TITLE
Fix migrations to have typo

### DIFF
--- a/backend/db/migrations/j0tkounk.update-labels.sql
+++ b/backend/db/migrations/j0tkounk.update-labels.sql
@@ -23,7 +23,7 @@ UPDATE annotation_option
 
 UPDATE annotation_option
   SET name = 'Hispanic', sort_order = 3
-  WHERE name = 'latino/a';
+  WHERE name = 'lantino/a';
 
 INSERT INTO annotation_option (annotation_attribute_id, name, sort_order)
   VALUES (3, 'Middle Eastern', 4);
@@ -85,8 +85,11 @@ UPDATE annotation_option
   WHERE name = 'Black';
 
 UPDATE annotation_option
-  SET name = 'latino/a'
+  SET name = 'lantino/a'
   WHERE name = 'Hispanic';
+
+DELETE FROM image_annotation
+  WHERE annotation_option_id = (SELECT id FROM annotation_option WHERE name = 'Middle Eastern');
 
 DELETE FROM annotation_option
   WHERE name = 'Middle Eastern';


### PR DESCRIPTION
Fixes #148 (but you need to migrate:reset or migrate:down until you revert "update-labels" and then migrate:up to fix it)