### PR TITLE
Improve age slider UX (#163 )

### DIFF
--- a/frontend/components/PerceivedDemographics.styl
+++ b/frontend/components/PerceivedDemographics.styl
@@ -82,6 +82,108 @@ fieldset, .reviewAnnotations {
   visually-hidden();
 }
 
+.rangeSlider {
+  position: relative;
+  margin-top: 1em;
+  padding: 1em;
+  text-align: center;
+  
+  .rangeSliderValueBold {
+    font-weight: 700;
+  }
+  
+  .rangeSliderValue {
+    margin-bottom: 1em;
+    text-transform: uppercase;
+  }
+  
+  .rangeSliderLines {
+    width: 105%;
+    margin: .5em 0 0 2.5%;
+    height: .5em;
+    background: repeating-linear-gradient(
+      to right,
+      #cacaca,
+      #cacaca 1px,
+      white 1px,
+      white 10%
+    );
+  }
+  
+  .rangeSliderValueLabels {
+    font-size: .9em;
+    font-weight: 400;
+    color: #989898;
+    
+    span {
+      display: inline-block;
+      width: 33.333333%;
+    }
+    .rangeSliderFirstValue {
+      text-align: left;
+    }
+    .rangeSliderMiddleValue {
+      text-align: center;
+    }
+    .rangeSliderLastValue {
+      text-align: right;
+    }
+  }
+  
+  input[type=range] {
+    -webkit-appearance: none;
+    margin: 1.5em 0 1em;
+    width: 100%;
+  }
+  
+  input[type=range]:focus {
+    outline: none;
+  }
+  
+  input[type=range]::-webkit-slider-runnable-track {
+    very-rounded();
+    height: .5em;
+    width: 100%;
+    cursor: pointer;
+    animate: 0.2s;
+    background: $gray-2;
+  }
+  
+  input[type=range]::-webkit-slider-thumb {
+    position: relative;
+    height: 2em;
+    width: 2em;
+    border-radius: 1em;
+    background: $aqua;
+    cursor: pointer;
+    -webkit-appearance: none;
+    margin-top: -.75em;
+    box-shadow: 0 1px 3px rgba(0,0,0,.5);
+    
+    &:after {
+      content: ' ';
+      position: absolute;
+      height: 1em;
+      width: 1em;
+      background-color: white;
+    }
+  }
+
+  .nextButton {
+    button();
+    background: $aqua;
+    border: 0;
+    width: 100%;
+    color: white;
+    font-size: 1em;
+    margin-top: 1em;
+    
+    &:hover {
+      background: $aqua;
+    }
+  }
+}
+
 @media only screen and (min-width: 26em) { 
    
   fieldset .progressBarContainer {
@@ -94,6 +196,10 @@ fieldset, .reviewAnnotations {
   
   .save {
     margin: 0 1.5em 1.5em;
+  }
+  
+  .rangeSlider {
+    padding: 1em 1.5em;
   }
 }
 
@@ -131,75 +237,8 @@ fieldset, .reviewAnnotations {
   .save {
     margin: 0 2.5em 2.5em;
   }
-}
-
-.rangeSlider {
-  position: relative;
-  margin-top: 1em;
-  padding: 1em;
-  text-align: center;
   
-  .rangeSliderValue {
-    position: relative;
-    padding: .5em;
-    background-color: $gray-2;
-    display: inline-block;
-    margin-bottom: .5em;
-     
-    &:after {
-      content: '';
-      position: absolute;
-      width: 0;
-      height: 0;
-      border-left: 8px solid transparent;
-      border-right: 8px solid transparent;
-      border-top: 8px solid $gray-2;
-      left: 0;
-      right: 0;
-      margin: auto;
-      bottom: -8px;
-    }
-  }
-  
-  input[type=range] {
-    -webkit-appearance: none;
-    margin: 18px 0;
-    width: 100%;
-  }
-  
-  input[type=range]:focus {
-    outline: none;
-  }
-  
-  input[type=range]::-webkit-slider-runnable-track {
-    very-rounded();
-    height: .5em;
-    width: 100%;
-    cursor: pointer;
-    animate: 0.2s;
-    background: $gray-2;
-  }
-  
-  input[type=range]::-webkit-slider-thumb {
-    height: 2em;
-    width: 1em;
-    background: $aqua;
-    cursor: pointer;
-    -webkit-appearance: none;
-    margin-top: -.75em;
-  }
-
-  .nextButton {
-    button();
-    background: $aqua;
-    border: 0;
-    width: 100%;
-    color: white;
-    font-size: 1em;
-    margin-top: 1em;
-    
-    &:hover {
-      background: $aqua;
-    }
+  .rangeSlider {
+    padding: 1em 2.5em 2em;
   }
 }

--- a/frontend/components/RangeSlider.jsx
+++ b/frontend/components/RangeSlider.jsx
@@ -32,7 +32,12 @@ export default class RangeSlider extends Component {
     } = this;
     return (
       <div className={styles.rangeSlider}>
-        <div className={styles.rangeSliderValue}>{value} years old</div>
+        <div className={styles.rangeSliderValueLabels}>
+          <span className={styles.rangeSliderFirstValue}>10</span>
+          <span className={styles.rangeSliderMiddleValue}>55</span>
+          <span className={styles.rangeSliderLastValue}>100</span>
+        </div>
+        <div className={styles.rangeSliderLines}></div>
         <input
           type="range"
           min={min}
@@ -40,6 +45,9 @@ export default class RangeSlider extends Component {
           value={value}
           onChange={this.handleInputChange}
         />
+        <div className={styles.rangeSliderValue}>
+          <span className={styles.rangeSliderValueBold}>{value}</span> years old
+        </div>
         <button className={styles.nextButton} onClick={this.handleClick}>Next</button>
       </div>
     );

--- a/frontend/components/RangeSlider.jsx
+++ b/frontend/components/RangeSlider.jsx
@@ -37,7 +37,7 @@ export default class RangeSlider extends Component {
           <span className={styles.rangeSliderMiddleValue}>55</span>
           <span className={styles.rangeSliderLastValue}>100</span>
         </div>
-        <div className={styles.rangeSliderLines}></div>
+        <div className={styles.rangeSliderLines} />
         <input
           type="range"
           min={min}


### PR DESCRIPTION
I made some improvements to the current age slider. Here a screenshot of how it looks:

![screenshot 2017-04-05 16 16 13](https://cloud.githubusercontent.com/assets/1379244/24730882/406b4a82-1a1b-11e7-8edb-6f7ecf9b8d1c.png)

As a side note I would like to point out that I couldn't figure out for this PR how to set a default value. Right now every time the user annotates an image and gets back to the first step, they will see the value they selected for the previous image, which is not ideal.