### PR TITLE
Rework calculation of image workload

### DIFF
--- a/backend/db/migrations/j16lc8mk.flagging-view.sql
+++ b/backend/db/migrations/j16lc8mk.flagging-view.sql
@@ -1,0 +1,46 @@
+CREATE OR REPLACE VIEW image_annotators_count AS
+WITH tabulator AS (
+  SELECT DISTINCT
+    annotator_id,
+    image_id,
+    flag
+  FROM image_annotation ia
+    LEFT JOIN annotation_option ao ON ia.annotation_option_id = ao.id
+    LEFT JOIN annotation_attribute a ON ao.annotation_attribute_id = a.id ORDER BY image_id
+),
+counted AS (
+  SELECT
+    image.id AS image_id,
+    COUNT(*) FILTER (WHERE flag) AS flags,
+    COUNT(*) FILTER (WHERE NOT flag) AS annotations
+  FROM
+    image
+    LEFT JOIN tabulator ON image.id = tabulator.image_id
+  GROUP BY image.id
+)
+SELECT
+  image_id,
+  flags,
+  annotations,
+  annotations > 0 AS started,
+  annotations >= 10 AS complete,
+  flags > 1 AND flags > annotations AS flagged
+FROM counted;
+
+CREATE INDEX image_annotation_image_id ON
+  image_annotation (image_id);
+
+ALTER TABLE image
+  ADD seed BOOLEAN NOT NULL DEFAULT False;
+
+UPDATE image
+  SET seed = True
+  WHERE id = ANY(SELECT image_id FROM known);
+---
+
+DROP VIEW image_annotators_count;
+
+DROP INDEX image_annotation_image_id;
+
+ALTER TABLE image
+  DROP seed;

--- a/backend/endpoints/annotations/queries/getImages.sql
+++ b/backend/endpoints/annotations/queries/getImages.sql
@@ -18,7 +18,8 @@ all_images AS (
     image.url,
     image.width,
     image.height,
-    image.seed as is_known
+    image.seed as is_known,
+    annotator.count as self_count
   FROM
     image
     LEFT JOIN annotator ON image.id = annotator.image_id
@@ -48,12 +49,12 @@ unknown_bucket AS (
 -- Select the right number of known/unknowns at random from the buckets
 knowns AS (
   SELECT * FROM known_bucket
-  ORDER BY RANDOM()
+  ORDER BY self_count NULLS FIRST, RANDOM()
   LIMIT ${numTruths}
 ),
 news AS (
   SELECT * FROM unknown_bucket
-  ORDER BY RANDOM()
+  ORDER BY self_count NULLS FIRST, RANDOM()
   LIMIT ${limit}
 ),
 final_workload AS (
@@ -61,4 +62,6 @@ final_workload AS (
 )
 
 -- Randomize the final selection so all the known images don't show up first every time
-SELECT * FROM final_workload ORDER BY RANDOM();
+SELECT
+  id, url, width, height, is_known
+FROM final_workload ORDER BY RANDOM();

--- a/backend/endpoints/annotations/queries/getImages.sql
+++ b/backend/endpoints/annotations/queries/getImages.sql
@@ -1,75 +1,64 @@
--- OLD QUERY
--- SELECT
---   image.id,
---   image.url,
---   image.width,
---   image.height
--- FROM
---   image
--- ORDER BY RANDOM()
--- LIMIT ${limit}
+WITH
 
--- NEW QUERY:
--- First, select the total count of annotaiton attributes
-WITH attributes as (
-  SELECT
-    COUNT(*) as count
-  FROM
-    annotation_attribute
-),
--- How many known truths are present for each image
-known_count as (
+-- Get a count for how many annotations this annotator has put on each image
+annotator AS (
   SELECT
     image_id,
     COUNT(*) as count
-  FROM
-    known
-  GROUP BY image_id
-),
--- Each annotator should never see the same image twice
-annotator as (
-  SELECT
-    image_id,
-    count(*) as count
   FROM image_annotation
-  WHERE annotator_id = ${annotatorId}
+  WHERE
+    annotator_id = ${annotatorId}
   GROUP BY image_id
 ),
--- Look for images, calculate if we can use them as knowns
--- sort the images we've alread annotated to be last, and randomize order
-truth_table as (
+
+-- Get a list of all images, removing flagged images, ordering them in "rough priority order"
+all_images AS (
   SELECT
     image.id,
     image.url,
     image.width,
     image.height,
-    COALESCE(known.count = attributes.count, false) as is_known
+    image.seed as is_known
   FROM
     image
-    LEFT JOIN known_count known on image.id = known.image_id
-    LEFT JOIN annotator on image.id = annotator.image_id,
-    attributes
+    LEFT JOIN annotator ON image.id = annotator.image_id
+    LEFT JOIN image_annotators_count crowd ON image.id = crowd.image_id
+  WHERE NOT crowd.flagged
+  -- Sort images this annotator hasn't annotated first
   ORDER BY annotator.count NULLS FIRST,
-    RANDOM()
+  -- Images that are not "complete" by the crowd source table
+    crowd.complete,
+  -- Images that have been "started" first
+    crowd.started DESC
 ),
--- Select the first "8" (2/3's of the limit) known images
-truths as (
-  SELECT * FROM truth_table WHERE is_known LIMIT ${numTruths}
-),
--- Select a whole "limit" bucket of unknown images
-news as (
-  SELECT * FROM truth_table WHERE NOT(is_known) LIMIT ${limit}
-),
--- Select the union of the known images, and unknown images, limiting to
--- the total limit (so because we "overfilled" the buffer for the unknowns)
--- it will always give us 12 images, with up to `numTruths` truths if we
--- had them...
 
-all_images as (
-  SELECT * FROM truths
-  UNION ALL
-  SELECT * FROM news
+-- Limit the previous select to a few thousand of the
+-- sorted images per known/unknown
+known_bucket AS (
+  SELECT * FROM all_images
+  WHERE is_known
+  LIMIT 1000
+),
+unknown_bucket AS (
+  SELECT * FROM all_images
+  WHERE NOT is_known
+  LIMIT 2000
+),
+
+-- Select the right number of known/unknowns at random from the buckets
+knowns AS (
+  SELECT * FROM known_bucket
+  ORDER BY RANDOM()
+  LIMIT ${numTruths}
+),
+news AS (
+  SELECT * FROM unknown_bucket
+  ORDER BY RANDOM()
   LIMIT ${limit}
+),
+final_workload AS (
+  SELECT * FROM knowns UNION SELECT * FROM news LIMIT ${limit}
 )
 
-SELECT * FROM all_images ORDER BY RANDOM();
+-- Randomize the final selection so all the known images don't show up first every time
+SELECT * FROM final_workload ORDER BY RANDOM();

--- a/backend/endpoints/annotations/queries/getOverallStats.sql
+++ b/backend/endpoints/annotations/queries/getOverallStats.sql
@@ -1,6 +1,6 @@
 SELECT
-  count(DISTINCT a.image_id) AS annotated_count,
-  count(DISTINCT i.id) AS total_count
+  COUNT(*) AS total_count,
+  COUNT(*) FILTER (WHERE started) AS annotated_count,
+  COUNT(*) FILTER (WHERE complete) AS complete_count
 FROM
-  image i
-  LEFT JOIN image_annotation a ON a.image_id = i.id
+  image_annotators_count;


### PR DESCRIPTION
Finishes #136 

Images are now not selected after reaching the "flagged" threshold which is defined as `flags > 1 AND flags > annotations`

I defined the query powering this as a VIEW so that it could be reused in a few places (and updated the get overall stats to use that as an example)