### PR TITLE
Clarify where vault is populated

### DIFF
--- a/ansible/vars/main.yml
+++ b/ansible/vars/main.yml
@@ -5,6 +5,7 @@ commit: master
 git_repo: https://github.com/bocoup/image-annotator.git
 
 # Get secrets from vault, or an empty dictonary if we don't need them.
+# Note that the `vault` variable is typically populated by secrets.yml
 secrets: "{{vault | default({})}}"
 
 # Control environment variables for each supported environment.


### PR DESCRIPTION
As per @tkellen's request, here's a PR clarifying how the secrets variable is setup. In particular, I initially found it confusing thinking that `vault` was a special keyword since I hadn't looked inside the secrets.yml file. 