### PR TITLE
Add check to ensure rolled back deploy is symlinked

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -41,6 +41,16 @@
         get_md5: no
       register: sha_dir
 
+    # if a commit is specified that has already been checked out,
+    # make sure it is symlinked before aborting the deploy process.
+    - name: rolling back to previously deployed commit {{commit}}
+      file:
+        path: "{{site_path}}"
+        state: link
+        src: "{{base_path}}/{{sha.stdout | default(commit)}}"
+        force: yes
+      when: "{{sha_dir.stat.exists}}"
+
     - name: refuse to continue if commit is already deployed
       fail:
         msg: "{{sha.stdout}} has been deployed already, aborting."


### PR DESCRIPTION
As per @tkellen's recommendation, this change makes sure a symlink is made to a previously deployed directory before failing the build. It should enable modifying the `commit` variable and running the deploy playbook again to switch to that commit if it is in the last 3 deployed commits (i.e., it has a folder on the server).