### PR TITLE
Csv report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ dist
 **.retry
 
 responses.csv
+annotations.csv

--- a/ansible/download-annotations.yml
+++ b/ansible/download-annotations.yml
@@ -4,7 +4,7 @@
     - vars/secrets.yml
   tasks:
     - name: export annotations
-      shell: psql -c "COPY (SELECT * FROM image_annotation_report) TO STDOUT WITH CSV"
+      shell: psql -c "COPY (SELECT * FROM image_annotation_report) TO STDOUT WITH CSV HEADER"
       environment: "{{env_vars[env]}}"
       register: annotations
 

--- a/ansible/download-annotations.yml
+++ b/ansible/download-annotations.yml
@@ -1,0 +1,15 @@
+- hosts: all
+  vars_files:
+    - vars/main.yml
+    - vars/secrets.yml
+  tasks:
+    - name: export annotations
+      shell: psql -c "COPY (SELECT * FROM image_annotation_report) TO STDOUT WITH CSV"
+      environment: "{{env_vars[env]}}"
+      register: annotations
+
+    - name: write annotations to current directory
+      copy:
+        dest: "{{lookup('env','PWD')}}/annotations.csv"
+        content: "{{annotations.stdout}}"
+      delegate_to: localhost

--- a/backend/db/migrations/j1m9znv3.report-view.sql
+++ b/backend/db/migrations/j1m9znv3.report-view.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE VIEW image_annotation_report AS
+  SELECT
+    ia.id,
+    ia.annotator_id,
+    ia.workload_id,
+    ia.image_id,
+    i.url,
+    aa.name AS attribute,
+    ao.name AS value
+  FROM image_annotation ia
+    LEFT JOIN image i ON ia.image_id = i.id
+    LEFT JOIN annotation_option ao ON ia.annotation_option_id = ao.id
+    LEFT JOIN annotation_attribute aa ON ao.annotation_attribute_id = aa.id;
+---
+DROP VIEW image_annotation_report;

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "provision:production": "ansible-playbook --ask-vault-pass --ask-sudo-pass -i ansible/inventory/production ansible/provision.yml",
     "deploy:production": "ansible-playbook --ask-vault-pass -i ansible/inventory/production ansible/deploy.yml",
     "database-restore:production": "ansible-playbook --ask-sudo-pass -i ansible/inventory/production ansible/database-restore.yml",
+    "download-annotations": "ansible-playbook --ask-vault-pass -i ansible/inventory/production ansible/download-annotations.yml",
     "download-feedback": "ansible-playbook --ask-vault-pass -i ansible/inventory/production ansible/download-feedback.yml"
   },
   "jest": {


### PR DESCRIPTION
Adds `npm run download-annotations` which makes an `annotations.csv`

I deployed the migration to the production server already, so you can test this command.

Closes #206